### PR TITLE
Construct file paths to LD scores instead of changing working directory

### DIFF
--- a/R/ldsc.R
+++ b/R/ldsc.R
@@ -553,6 +553,9 @@ ldsc <- function(traits,sample.prev,population.prev,ld,wld,trait.names=NULL,sep_
   cat(print(paste0("Running LDSC for all files took ",mins," minutes and ",secs," seconds"), sep = ""),file=log.file,sep="\n",append=TRUE)
   cat(paste("     "),file=log.file,sep="\n",append=TRUE)
   
+  flush(log.file)
+  close(log.file)
+
   if(stand == FALSE){
   return(list(V=V,S=S,I=I,N=N.vec,m=m))
   }

--- a/R/ldsc.R
+++ b/R/ldsc.R
@@ -38,34 +38,27 @@ ldsc <- function(traits,sample.prev,population.prev,ld,wld,trait.names=NULL,sep_
   Liab.S <- matrix(1,nrow=1,ncol=n.traits)
   I <- matrix(NA,nrow=n.traits,ncol=n.traits)
   
-  # Current working directory
-  curwd = getwd()
-  
-  
   
   #########  READ LD SCORES:
   cat(print("Reading in LD scores"),file=log.file,sep="\n",append=TRUE)
-  setwd(ld)
+
   
-  x <- suppressMessages(read_delim("1.l2.ldscore.gz", "\t", escape_double = FALSE, trim_ws = TRUE,progress = F))
+  x <- suppressMessages(read_delim(file.path(ld, "1.l2.ldscore.gz"), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F))
   for(i in 2:chr){
-    x <- rbind(x,suppressMessages(read_delim(paste0(i,".l2.ldscore.gz"), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F)))
+    x <- rbind(x,suppressMessages(read_delim(file.path(ld, paste0(i,".l2.ldscore.gz")), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F)))
   }
   
   x$CM <- NULL
   x$MAF <- NULL
-  
-  setwd(curwd)
+
   
   ######### READ weights:
   
   
-  setwd(wld)
-  
   if(sep_weights==T){
-    w <- suppressMessages(read_delim("1.l2.ldscore.gz", "\t", escape_double = FALSE, trim_ws = TRUE,progress = F))
+    w <- suppressMessages(read_delim(file.path(wld, "1.l2.ldscore.gz"), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F))
     for(i in 2:chr){
-      w <- rbind(w,suppressMessages(read_delim(paste0(i,".l2.ldscore.gz"), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F)))
+      w <- rbind(w,suppressMessages(read_delim(file.path(wld, paste0(i,".l2.ldscore.gz")), "\t", escape_double = FALSE, trim_ws = TRUE,progress = F)))
     }   }
   
   w <- x
@@ -73,17 +66,15 @@ ldsc <- function(traits,sample.prev,population.prev,ld,wld,trait.names=NULL,sep_
   w$CM <- NULL
   w$MAF <- NULL
   
-  setwd(curwd)
-  
   colnames(w)[ncol(w)] <- "wLD"
   
   ### READ M
-  setwd(ld)
-  m  <- suppressMessages(read_csv("1.l2.M_5_50",  col_names = FALSE))
+  
+  m  <- suppressMessages(read_csv(file.path(ld, "1.l2.M_5_50"),  col_names = FALSE))
   for(i in 2:chr){
-    m <- rbind(m,suppressMessages(read_csv(paste0(i,".l2.M_5_50"),  col_names = FALSE)))
+    m <- rbind(m,suppressMessages(read_csv(file.path(ld, paste0(i,".l2.M_5_50")),  col_names = FALSE)))
   }
-  setwd(curwd)
+  
   M.tot <- sum(m)
   m <- M.tot
   

--- a/R/munge.R
+++ b/R/munge.R
@@ -212,4 +212,7 @@ munge <- function(files,hm3,trait.names=NULL,N,info.filter = .9,maf.filter=0.01)
   cat(print(paste0("The munging of all files took ",mins," minutes and ",secs," seconds"), sep = ""),file=log.file,sep="\n",append=TRUE)
   cat(print(paste("Please check the log file", paste0(log2, "_munge.log"), "to ensure that all columns were interpreted correctly and no warnings were issued for any of the summary statistics files")),file=log.file,sep="\n",append=TRUE)
     
+  flush(log.file)
+  close(log.file)
+    
 }

--- a/R/sumstats.R
+++ b/R/sumstats.R
@@ -641,6 +641,9 @@ sumstats <- function(files,ref,trait.names=NULL,se.logit,OLS=NULL,linprob=NULL,p
     print(paste0("Running sumstats for all files took ",mins," minutes and ",secs," seconds"), sep = "")
     print(paste0("Please check the log files to ensure that all columns were interpreted correctly and no warnings were issued for any of the summary statistics files."))
   }
+
+  flush(log.file)
+  close(log.file)
   
   data.frame.out
   


### PR DESCRIPTION
Small change to the `ldsc()` function to open the LD score and M files by path using `file.path(ld, ...)` and `file.path(wld, ...)` instead of `setwd()`.

This solves an issue where the working directory does not reset if there are any problems reading in the LD score files, which can strand the session inside the `ld` or `wld` directory after the function returns.

Also added commands to close the log files before user functions exit which fixes the message:

```
In for (i in (1L:cols)[do]) { :
  closing unused connection 3 (trait1_trait2_trait3_munge.log)
```