### PR TITLE
QTrait input checks

### DIFF
--- a/R/qtrait.r
+++ b/R/qtrait.r
@@ -22,6 +22,17 @@ QTrait <- function(LDSCoutput,indicators,traits,
     }
   }
   
+  # check if LDSCoutput is a list with the expected elements
+  if(!is.list(LDSCoutput) | any(!c("V", "S", "I", "N", "m") %in% names(LDSCoutput))) {
+    LDSCoutput_name <- deparse(substitute(LDSCoutput))
+    stop(paste(LDSCoutput_name, "is not an ldsc() object"))
+  }
+  
+  # check if LDSCoutput has genetic correlation matrices
+  if(!all(c("V_Stand", "S_Stand") %in% names(LDSCoutput))) {
+    stop(paste("QTrait() requires a genetic correlation and sampling correlation matrix. Rebuild the covariance structure with ldsc(..., stand = TRUE)"))
+  }
+  
   # Write Common Factor Model syntax 
   CF_model_syntax <- paste(
     paste("F1 =~ ", paste(indicators, collapse = " + ",sep=""), collapse = " "),


### PR DESCRIPTION
Adds some flexibility and checks for the `LDSCoutput` argument to `QTrait()`

- checks if `LDSCoutput` is a string or a list.
- if `LDSCoutput`  is a string, checks if it is a path and attempts to load the serialised data.
- doesn't assume what name serialised data object has (though it does assume only 1 object was serialised)
- if `LDSCoutput` is a list, checks that it has expected named elements
- gives informative error if list doesn't have genetic correlation matrix 