### PR TITLE
Updated QTrait function for Bioinformatics Major Revision

### DIFF
--- a/R/qtrait.r
+++ b/R/qtrait.r
@@ -487,7 +487,7 @@ if(SigHet=="No"){
                    nested_chi,nested_df,pchisq(nested_chi, nested_df, lower.tail = FALSE),Qsignificant,
                    lsrmr_cpm,lSRMR_above_threshold,SigHet,
                    "-","-","-","-",
-                   "-","-","-","-",
+                   "-","-","-","-","-",
                    "-","-","-","None")
     }
   


### PR DESCRIPTION
Updated QTrait function for Bioinformatics Major Revision:
- feature: added percentage reduction of lSRMR from common-pathway model to the last follow-up model.
- feature: added warning when the number of outlying indicators surpasses 50% of the total number of indicator traits.
- fix: fixed output for external correlates without outlying indicators to include "-" for the % reduction in lSRMR column.
- fix: fixed output results table to include missing data (i.e., "-") for % reduction lSRMR when there's no heterogeneity.