### PR TITLE
Add outdir parameter to munge function

### DIFF
--- a/R/munge.R
+++ b/R/munge.R
@@ -1,5 +1,5 @@
 munge <- function(files,hm3,trait.names=NULL,N=NULL,info.filter = .9,maf.filter=0.01,log.name=NULL, column.names=list(),
-                  parallel=FALSE, cores=NULL, overwrite=TRUE){
+                  parallel=FALSE, cores=NULL, overwrite=TRUE, outdir=NULL){
   if (is.list(files)) {
     wrn <- paste0("DeprecationWarning: In future versions a list of filenames will no longer be accepted.\n",
                   "                    Please change files to a vector to ensure future compatibility.")
@@ -28,6 +28,13 @@ munge <- function(files,hm3,trait.names=NULL,N=NULL,info.filter = .9,maf.filter=
   .check_boolean(parallel)
   if (!is.null(cores)) .check_range(cores, min=0, max=Inf)
   .check_boolean(overwrite)
+  if (!is.null(outdir)) {
+    if (!is.character(outdir) || length(outdir) != 1) stop("outdir must be a single character string specifying the output directory.")
+    if (!dir.exists(outdir)) dir.create(outdir, recursive=TRUE)
+    outdir <- normalizePath(outdir)
+  } else {
+    outdir <- getwd()
+  }
   # Sanity checks finished
 
   filenames <- as.vector(files)
@@ -51,7 +58,7 @@ munge <- function(files,hm3,trait.names=NULL,N=NULL,info.filter = .9,maf.filter=
   if (overwrite) {
     existing_files <- c()
     for (trait.name in trait.names) {
-      if (file.exists(paste0(trait.name, ".sumstats")))
+      if (file.exists(file.path(outdir, paste0(trait.name, ".sumstats"))))
         existing_files <- c(existing_files, paste0(trait.name, ".sumstats"))
     }
     if (length(existing_files) > 0)
@@ -65,7 +72,7 @@ munge <- function(files,hm3,trait.names=NULL,N=NULL,info.filter = .9,maf.filter=
     files <- lapply(files, read.table, header=T, quote="\"", fill=T, na.string=c(".", NA, "NA", ""))
     .LOG("All files loaded into R!",file=log.file)
     for(i in 1:length(files)){
-      .munge_main(i, NULL, files[[i]], filenames[i], trait.names[i], N[i], ref, hm3, info.filter, maf.filter, column.names, overwrite, log.file)
+      .munge_main(i, NULL, files[[i]], filenames[i], trait.names[i], N[i], ref, hm3, info.filter, maf.filter, column.names, overwrite, log.file, outdir)
     }
   } else {
     if(is.null(cores)){
@@ -90,7 +97,7 @@ munge <- function(files,hm3,trait.names=NULL,N=NULL,info.filter = .9,maf.filter=
     utilfuncs[["gzip"]] <- gzip
     .LOG("As parallel munging was requested, logs of each sumstats file will be saved separately",file=log.file)
     foreach (i=1:length(filenames), .export=c(".munge_main"), .packages=c("stringr")) %dopar% {
-      .munge_main(i, utilfuncs, NULL, filenames[i], trait.names[i], N[i], ref, hm3, info.filter, maf.filter, column.names, overwrite, NULL)
+      .munge_main(i, utilfuncs, NULL, filenames[i], trait.names[i], N[i], ref, hm3, info.filter, maf.filter, column.names, overwrite, NULL, outdir)
     }
   }
   

--- a/R/munge_main.R
+++ b/R/munge_main.R
@@ -1,4 +1,4 @@
-.munge_main <- function(i, utilfuncs, file, filename, trait.name, N, ref, hm3, info.filter, maf.filter, column.names, overwrite, log.file=NULL) {
+.munge_main <- function(i, utilfuncs, file, filename, trait.name, N, ref, hm3, info.filter, maf.filter, column.names, overwrite, log.file=NULL, outdir=getwd()) {
   if (is.null(log.file)) {
     log.file <- file(paste0(trait.name, "_munge.log"),open="wt")
     on.exit(flush(log.file))
@@ -130,9 +130,9 @@ Please note that this is likely effective sample size cut in half. The function 
   #remove spaces in trait.names file to avoid errors with fread functionality used for s_ldsc
   trait.name<-str_replace_all(trait.name, fixed(" "), "") 
   
-  write.table(x = output,file = paste0(trait.name,".sumstats"),sep="\t", quote = FALSE, row.names = F)
-  gzip(paste0(trait.name,".sumstats"), overwrite=overwrite)
+  write.table(x = output,file = file.path(outdir, paste0(trait.name,".sumstats")),sep="\t", quote = FALSE, row.names = F)
+  gzip(file.path(outdir, paste0(trait.name,".sumstats")), overwrite=overwrite)
   .LOG("I am done munging file: ", filename,file=log.file)
-  .LOG("The file is saved as ", paste0(trait.name,".sumstats.gz"), " in the current working directory.",file=log.file)
+  .LOG("The file is saved as ", paste0(trait.name,".sumstats.gz"), " in the directory: ", outdir,file=log.file)
   return()
 }

--- a/man/munge.Rd
+++ b/man/munge.Rd
@@ -5,7 +5,7 @@
 Function to process GWAS summary statistis files and prepair them for LD score regression 
 }
 \usage{
-munge(files,hm3,trait.names=NULL,N,info.filter = .9,maf.filter=0.01, column.names=list(),parallel=FALSE,cores=NULL,overwrite=TRUE \dots)
+munge(files,hm3,trait.names=NULL,N,info.filter = .9,maf.filter=0.01, column.names=list(),parallel=FALSE,cores=NULL,overwrite=TRUE,outdir=NULL \dots)
 
 }
 \arguments{
@@ -19,6 +19,7 @@ munge(files,hm3,trait.names=NULL,N,info.filter = .9,maf.filter=0.01, column.name
    \item{parallel}{Indicates whether munge should process the summary statistics files in parallel or serial fashion. Default is TRUE, indicating that it will run in parallel.}
    \item{cores}{Indicates how many cores to use when running in parallel. The default is NULL, in which case munge will use 1 less than the total number of cores available in the local environment.}
    \item{overwrite}{Indicates whether existing .sumstats.gz files should be overwritten}
+   \item{outdir}{Optional character string specifying the directory where munged .sumstats.gz files will be written. If NULL (default), files are written to the current working directory. The directory will be created if it does not exist.}
 }
 
 \value{


### PR DESCRIPTION
Specification of where you want your .sumstats.gz files saved after munge. Logs remain in current wd. log output updated to inlcude specified outdir rather than just saying current wd. Makes for smoother pipeline construction. 