### PR TITLE
Updates to add Gauss-Newton functionality for usergwas() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,5 +8,6 @@ Description: Later
 License: GPL-3.0
 Encoding: UTF-8
 LazyData: true
-Imports: plyr,e1071,readr,gdata,lavaan,doParallel,parallel,foreach,data.table,stringr,splitstackshape,Matrix,R.utils,dplyr,iterators,Rcpp,utils,mgsub
+Imports: plyr,e1071,readr,gdata,lavaan (== 0.6-21.0001),doParallel,parallel,foreach,data.table,stringr,splitstackshape,Matrix,R.utils,dplyr,iterators,Rcpp,utils,mgsub
 RoxygenNote: 7.2.3
+Remotes: github::ykhan1999/lavaan

--- a/R/userGWAS.R
+++ b/R/userGWAS.R
@@ -1,6 +1,6 @@
 userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", printwarn=TRUE,
                      sub=FALSE,cores=NULL, toler=FALSE, SNPSE=FALSE, parallel=TRUE, GC="standard", MPI=FALSE,
-                     smooth_check=FALSE, TWAS=FALSE, std.lv=FALSE,fix_measurement=TRUE,Q_SNP=FALSE){
+                     smooth_check=FALSE, TWAS=FALSE, std.lv=FALSE,fix_measurement=TRUE,Q_SNP=FALSE,GN=FALSE){
   
   # Set toler to machine precision to enable passing this to solve() directly
   if (!toler) toler <- .Machine$double.eps
@@ -237,7 +237,7 @@ userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", prin
   f <- nrow(beta_SNP)
   # Run a single SNP to obtain base Lavaan model object
   LavModel1 <- .userGWAS_main(i=1, cores=1, n_phenotypes, n=1, I_LD, V_LD, S_LD, std.lv, varSNPSE2, order, SNPs, beta_SNP, SE_SNP, varSNP, GC,
-                              coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, returnlavmodel=TRUE,Q_SNP=Q_SNP,model=model)
+                              coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, returnlavmodel=TRUE,Q_SNP=Q_SNP,model=model,GN=GN)
   if(!parallel){
     #make empty list object for model results if not saving specific model parameter
     if(sub[[1]]==FALSE){
@@ -259,7 +259,7 @@ userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", prin
         }
       }
       final2 <- .userGWAS_main(i, cores=1, n_phenotypes, 1, I_LD, V_LD, S_LD, std.lv, varSNPSE2, order, SNPs, beta_SNP, SE_SNP, varSNP, GC,
-                               coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, basemodel=LavModel1,Q_SNP=Q_SNP,model=model)
+                               coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, basemodel=LavModel1,Q_SNP=Q_SNP,model=model,GN=GN)
       final2$i <- NULL
       if(sub[[1]] != FALSE){
         final3 <- as.data.frame(matrix(NA,ncol=ncol(final2),nrow=length(sub)))
@@ -326,7 +326,7 @@ userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", prin
         foreach (i=1:nrow(beta_SNP[[n]]), .combine='rbind', .packages = "lavaan") %dopar% 
         .userGWAS_main(i, int, n_phenotypes, n, I_LD, V_LD, S_LD,
                        std.lv, varSNPSE2, order, SNPs[[n]], beta_SNP[[n]], SE_SNP[[n]], varSNP[[n]], GC,
-                       coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, basemodel=LavModel1,Q_SNP=Q_SNP,model=model)
+                       coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1, df, npar, basemodel=LavModel1,Q_SNP=Q_SNP,model=model,GN=GN)
     } else {
       #Util-functions have to be explicitly passed to the analysis function in PSOCK cluster
       utilfuncs <- list()
@@ -340,7 +340,7 @@ userGWAS <- function(covstruc=NULL, SNPs=NULL, estimation="DWLS", model="", prin
                    .userGWAS_main(i, int, n_phenotypes, n, I_LD, V_LD, S_LD, std.lv, varSNPSE2, order,
                                   SNPs[[n]], beta_SNP[[n]], SE_SNP[[n]], varSNP[[n]], GC, coords,
                                   smooth_check, TWAS, printwarn, toler, estimation, sub, Model1,
-                                  df, npar, utilfuncs, basemodel=LavModel1,Q_SNP=Q_SNP,model=model)
+                                  df, npar, utilfuncs, basemodel=LavModel1,Q_SNP=Q_SNP,model=model,GN=GN)
                  }
     }
     

--- a/R/userGWAS_main.R
+++ b/R/userGWAS_main.R
@@ -213,7 +213,8 @@
     #Pull P1 (the eigen vectors of V_eta)
     P1 <- eigen(V_full)$vectors
     
-    implied <- as.matrix(fitted(Model1_Results))[1]
+    implied <- lavaan::lavInspect(Model1_Results, "implied")$cov
+    implied <- list(implied)
     implied_order <- colnames(S_Fullrun)
     implied[[1]] <- implied[[1]][implied_order,implied_order]
     implied2 <- S_Fullrun-implied[[1]]

--- a/R/userGWAS_main.R
+++ b/R/userGWAS_main.R
@@ -1,6 +1,6 @@
 .userGWAS_main <- function(i, cores, k, n, I_LD, V_LD, S_LD, std.lv, varSNPSE2, order, SNPs, beta_SNP, SE_SNP,
                            varSNP, GC, coords, smooth_check, TWAS, printwarn, toler, estimation, sub, Model1,
-                           df, npar, utilfuncs=NULL, basemodel=NULL, returnlavmodel=FALSE,Q_SNP,model) {
+                           df, npar, utilfuncs=NULL, basemodel=NULL, returnlavmodel=FALSE,Q_SNP,model,GN) {
   # utilfuncs contains utility functions to enable this code to work on PSOC clusters (for Windows)
   if (!is.null(utilfuncs)) {
     for (j in names(utilfuncs)) {
@@ -52,12 +52,23 @@
   ##run the model. save failed runs and run model. warning and error functions prevent loop from breaking if there is an error.
   if(estimation == "DWLS"){
     if (!is.null(basemodel)) {
-      test <- .tryCatch.W.E(Model1_Results <- lavaan(sample.cov = S_Fullrun, WLS.V=W, ordered=NULL, sampling.weights = NULL,se="standard",
+        if(GN == TRUE){
+              test <- .tryCatch.W.E(Model1_Results <- lavaan(sample.cov = S_Fullrun, WLS.V=W, ordered=NULL, sampling.weights = NULL,se="standard",
+                                                     sample.mean=NULL, sample.th=NULL, sample.nobs=2, group=NULL, cluster= NULL, constraints='', NACOV=NULL,
+                                                     slotOptions=basemodel@Options, slotParTable=basemodel@ParTable, slotSampleStats=NULL,
+                                                     slotData=basemodel@Data, slotModel=basemodel@Model, slotCache=NULL, sloth1=NULL, optim.method="gn"))
+        } else {
+              test <- .tryCatch.W.E(Model1_Results <- lavaan(sample.cov = S_Fullrun, WLS.V=W, ordered=NULL, sampling.weights = NULL,se="standard",
                                                      sample.mean=NULL, sample.th=NULL, sample.nobs=2, group=NULL, cluster= NULL, constraints='', NACOV=NULL,
                                                      slotOptions=basemodel@Options, slotParTable=basemodel@ParTable, slotSampleStats=NULL,
                                                      slotData=basemodel@Data, slotModel=basemodel@Model, slotCache=NULL, sloth1=NULL))
+        }
     } else {
-      test <- .tryCatch.W.E(Model1_Results <- sem(Model1, sample.cov = S_Fullrun, estimator = "DWLS",se="standard", WLS.V = W, sample.nobs = 2, optim.dx.tol = .01,std.lv=std.lv))
+      if(GN == TRUE){
+          test <- .tryCatch.W.E(Model1_Results <- sem(Model1, sample.cov = S_Fullrun, estimator = "DWLS",se="standard", WLS.V = W, sample.nobs = 2, optim.dx.tol = .01,std.lv=std.lv,optim.method="gn"))
+      } else {
+          test <- .tryCatch.W.E(Model1_Results <- sem(Model1, sample.cov = S_Fullrun, estimator = "DWLS",se="standard", WLS.V = W, sample.nobs = 2, optim.dx.tol = .01,std.lv=std.lv))
+      }
     }
   } else if(estimation == "ML"){
     if (!is.null(basemodel)) {


### PR DESCRIPTION
Hi,

I noticed that a significant bottleneck in the usergwas() computation for one of my models was the use of the nlminb optimizer, as computing the Hessian for each iteration over hundreds of iterations can take up to several seconds on a Ryzen 9955HX. Lavaan 0.6-21 has implemented a basic version of the Gauss-Newton optimizer, which is a more computationally efficient way to approximate the Hessian using the Jacobian matrix (https://doi.org/10.1007/bf02294574, https://doi.org/10.1007/bf02293789). This pull request implements two changes allowing users to take advantage of the Gauss-Newton method for increased computational efficiency when using userGWAS().

1. The userGWAS() function is updated to take a boolean argument GN. When set to TRUE, userGWAS_main passes optim.method="gn" into the lavaan() and sem() functions of the main loop.
2. The package description is updated to install a custom version of Lavaan (https://github.com/ykhan1999/lavaan), lavaan 0.6-21.0001, with modifications to the Gauss-Newton solver (R/lav_optim_gn.R) that allow inequality constraints in the gSEM model.

The latter change is not strictly necessary for GN functionality but without it, users will not be able to use the GN method if their model includes inequality constraints which I've used often in gSEM. It also adds the benefit of a version lock which could be helpful because the current development version of Lavaan involve changes to function names that break userGWAS().

In my own benchmarks, implementing the Gauss-Newton optimizer reduces step 11 (the optimization step) of lavaan from an average of ~300ms per run to ~10ms, which has a huge effect when iterating over millions of SNPs.

Thanks for considering my pull request and let me know if there are any questions!